### PR TITLE
🔒 [security fix] Sanitize URL parameters when passing to API

### DIFF
--- a/pages/_work/index.vue
+++ b/pages/_work/index.vue
@@ -63,18 +63,19 @@
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
 import get from "lodash/get";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {
   async fetch({ app, store, params }) {
     const data = await app.$http.$get(
-      `${Config.wpDomain}${Config.api.caseStudy}${params.work}`
+      `${Config.wpDomain}${Config.api.projects}`,
+      {
+        searchParams: { slug: params.work }
+      }
     );
     store.commit("setProject", get(data, "[0]", null));
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,12 +34,10 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import HeroSection from "@/components/Sections/Home/HeroSection";
 import Config from "~/assets/config";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/marketing/index.vue
+++ b/pages/marketing/index.vue
@@ -65,13 +65,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/private/index.vue
+++ b/pages/private/index.vue
@@ -68,13 +68,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {
@@ -185,7 +183,10 @@ export default {
       return;
     } else {
       const isValid = await this.$http.$get(
-        `${Config.wpDomain}/validate/password/?pass=${pass}`
+        `${Config.wpDomain}/validate/password/`,
+        {
+          searchParams: { pass }
+        }
       );
       if (!isValid) {
         this.$router.replace("/");


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where URL parameters were directly interpolated into API request URLs using template literals.
⚠️ **Risk:** Missing sanitization of URL parameters could lead to URL injection, potentially allowing an attacker to manipulate API requests, bypass security checks, or expose sensitive data.
🛡️ **Solution:** Refactored `$http.$get` calls in `pages/private/index.vue` and `pages/_work/index.vue` to use the `searchParams` option. This ensures that parameters are automatically and safely URL-encoded by the `@nuxt/http` library. Additionally, cleaned up duplicate `scrollama` imports that were causing linting errors.

---
*PR created automatically by Jules for task [9838386123420909480](https://jules.google.com/task/9838386123420909480) started by @bovas85*