### PR TITLE
🔒 [security fix] Sanitize URL parameters in API calls

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -15,7 +15,7 @@ export default {
     contactPage: '/wp/v2/pages/235/',
     aboutPage: '/wp/v2/pages/310/',
     projects: '/wp/v2/casestudies',
-    caseStudy: '/wp/v2/casestudies?slug=',
+    caseStudy: '/wp/v2/casestudies',
     postFormContact: '/contact-form-7/v1/contact-forms/78/feedback'
   }
 }

--- a/pages/_work/index.vue
+++ b/pages/_work/index.vue
@@ -63,18 +63,19 @@
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
 import get from "lodash/get";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {
   async fetch({ app, store, params }) {
     const data = await app.$http.$get(
-      `${Config.wpDomain}${Config.api.caseStudy}${params.work}`
+      `${Config.wpDomain}${Config.api.caseStudy}`,
+      {
+        searchParams: { slug: params.work }
+      }
     );
     store.commit("setProject", get(data, "[0]", null));
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,12 +34,10 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import HeroSection from "@/components/Sections/Home/HeroSection";
 import Config from "~/assets/config";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/marketing/index.vue
+++ b/pages/marketing/index.vue
@@ -65,13 +65,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/private/index.vue
+++ b/pages/private/index.vue
@@ -68,13 +68,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {
@@ -185,7 +183,10 @@ export default {
       return;
     } else {
       const isValid = await this.$http.$get(
-        `${Config.wpDomain}/validate/password/?pass=${pass}`
+        `${Config.wpDomain}/validate/password/`,
+        {
+          searchParams: { pass }
+        }
       );
       if (!isValid) {
         this.$router.replace("/");


### PR DESCRIPTION
Fixed security vulnerability where URL parameters were embedded directly into API requests. Switched to using `searchParams` for automatic encoding and sanitization. Also cleaned up redundant `scrollama` imports that were causing linting issues.

---
*PR created automatically by Jules for task [2106553200922608086](https://jules.google.com/task/2106553200922608086) started by @bovas85*