### PR TITLE
⚡ Refactor scrollama import and cleanup redundant imports

### DIFF
--- a/pages/_work/index.vue
+++ b/pages/_work/index.vue
@@ -63,12 +63,10 @@
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
 import get from "lodash/get";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,12 +34,10 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import HeroSection from "@/components/Sections/Home/HeroSection";
 import Config from "~/assets/config";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/marketing/index.vue
+++ b/pages/marketing/index.vue
@@ -65,13 +65,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {

--- a/pages/private/index.vue
+++ b/pages/private/index.vue
@@ -68,13 +68,11 @@
 <script>
 import scrollama from "scrollama";
 import debounce from "lodash/debounce";
-import scrollama from "scrollama";
 import Config from "~/assets/config";
 import WorkHero from "@/components/Sections/Work/WorkHero";
 import LazyImage from "@/components/UI/LazyImage";
 import get from "lodash/get";
 import Defer from "@/mixins/Defer";
-import scrollama from "scrollama";
 let scroller, steps;
 
 export default {


### PR DESCRIPTION
Refactored the `scrollama` import in `pages/private/index.vue` and other page files to use a single top-level import. This addresses the issue of redundant imports and ensures consistent, efficient dependency management.

The previously existing synchronous `require` inside the `scrollama` computed property (mentioned in the issue) had already been partially addressed, but left the codebase with triple redundant imports in several files. This change completes the cleanup.

Affected files:
- pages/private/index.vue
- pages/_work/index.vue
- pages/marketing/index.vue
- pages/index.vue

Verified with `yarn lint` and `yarn build`.

---
*PR created automatically by Jules for task [16716455531725739614](https://jules.google.com/task/16716455531725739614) started by @bovas85*