### PR TITLE
Enable ESLint auto-fix in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -197,7 +197,7 @@ export default {
           loader: "eslint-loader",
           exclude: /(node_modules)/,
           options: {
-            // fix: true
+            fix: true
           }
         });
       }


### PR DESCRIPTION
The \`fix: true\` option for \`eslint-loader\` was commented out in \`nuxt.config.js\`. This PR uncomments it to enable ESLint's auto-fix feature on save during development. This change is standard and helps maintain code quality by automatically applying formatting and simple fixes.

---
*PR created automatically by Jules for task [5284184671199247789](https://jules.google.com/task/5284184671199247789) started by @bovas85*