### PR TITLE
style: tweak homepage UI sizing

### DIFF
--- a/app/components/Sections/Home/WhoIAm.vue
+++ b/app/components/Sections/Home/WhoIAm.vue
@@ -140,12 +140,8 @@ section {
             @include size(h2);
           }
 
-          @include media(xl) {
-            @include size(h1);
-          }
-
           @include media(xxl) {
-            @include size(jumbo);
+            @include size(h1);
           }
 
           @include media(md) {

--- a/app/components/Sliders/TheCarousel.vue
+++ b/app/components/Sliders/TheCarousel.vue
@@ -199,6 +199,10 @@ const swiperOptions = {
     height: 600px;
   }
 
+  @include media(lg) {
+    height: 780px;
+  }
+
   .slide-content {
     height: 100%;
     width: 100%;
@@ -278,6 +282,10 @@ const swiperOptions = {
 
     @include media(sm) {
       height: 600px;
+    }
+
+    @include media(lg) {
+      height: 780px;
     }
 
     width: 100%;


### PR DESCRIPTION
- WhoIAm.vue: reduce font size on xl and xxl desktop screens to prevent unwanted text wrapping on the first line
- TheCarousel.vue: increase carousel slide height by 30% (600px -> 780px) on lg desktop screens and above